### PR TITLE
Update SSH2 dependency + replaced gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 'use strict';
 var path = require('path');
 var fs = require('fs');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
+var log = require('fancy-log');
 var util = require('util');
 var through = require('through2');
-var Connection = require('ssh2');
+const { Client } = require('ssh2');
 var async = require('async');
 var parents = require('parents');
 var Stream = require('stream');
@@ -19,7 +20,7 @@ module.exports = function (options) {
 
 
     if (options.host === undefined) {
-        throw new gutil.PluginError('gulp-sftp', '`host` required.');
+        throw new PluginError('gulp-sftp', '`host` required.');
     }
 
     var fileCount = 0;
@@ -32,7 +33,7 @@ module.exports = function (options) {
     if(options.authKey && fs.existsSync(authFile)){
         var auth = JSON.parse(fs.readFileSync(authFile,'utf8'))[options.authKey];
         if(!auth)
-            this.emit('error', new gutil.PluginError('gulp-sftp', 'Could not find authkey in .ftppass'));
+            this.emit('error', new PluginError('gulp-sftp', 'Could not find authkey in .ftppass'));
         if(typeof auth == "string" && auth.indexOf(":")!=-1){
             var authparts = auth.split(":");
             auth = {user:authparts[0],pass:authparts[1]};
@@ -86,7 +87,7 @@ module.exports = function (options) {
                 }
             }
         }else if(!key.contents){
-            this.emit('error', new gutil.PluginError('gulp-sftp', 'Cannot find RSA key, searched: '+key.location.join(', ')));
+            this.emit('error', new PluginError('gulp-sftp', 'Cannot find RSA key, searched: '+key.location.join(', ')));
         }
 
 
@@ -123,12 +124,12 @@ module.exports = function (options) {
             return uploader(sftpCache);
 
         if(options.password){
-            gutil.log('Authenticating with password.');
+            log.info('Authenticating with password.');
         }else if(key){
-            gutil.log('Authenticating with private key.');
+            log.info('Authenticating with private key.');
         }
 
-        var c = new Connection();
+        var c = new Client();
         connectionCache = c;
         c.on('ready', function() {
 
@@ -137,10 +138,10 @@ module.exports = function (options) {
                     throw err;
 
                 sftp.on('end', function() {
-                    gutil.log('SFTP :: SFTP session closed');
+                    log.info('SFTP :: SFTP session closed');
                     sftpCache=null;
                     if(!finished)
-                        this.emit('error', new gutil.PluginError('gulp-sftp', "SFTP abrupt closure"));
+                        this.emit('error', new PluginError('gulp-sftp', "SFTP abrupt closure"));
                 });
 
                 sftpCache = sftp;
@@ -150,21 +151,21 @@ module.exports = function (options) {
 
         var self = this;
         c.on('error', function(err) {
-            self.emit('error', new gutil.PluginError('gulp-sftp', err));
+            self.emit('error', new PluginError('gulp-sftp', err));
             //return cb(err);
         });
         c.on('end', function() {
-            gutil.log('Connection :: end');
+            log.info('Connection :: end');
         });
         c.on('close', function(err) {
             if(!finished){
-                gutil.log('gulp-sftp', "SFTP abrupt closure");
-                self.emit('error', new gutil.PluginError('gulp-sftp', "SFTP abrupt closure"));
+                log.error('gulp-sftp', "SFTP abrupt closure");
+                self.emit('error', new PluginError('gulp-sftp', "SFTP abrupt closure"));
             }
             if (err) {
-                gutil.log('Connection :: close, ', gutil.colors.red('Error: ' + err));
+                log.error('Connection :: close, Error: ' + err);
             } else {
-                gutil.log('Connection :: closed');
+                log.info('Connection :: closed');
             }
             
         });
@@ -252,9 +253,9 @@ module.exports = function (options) {
                     if (!exist) {
                         sftp.mkdir(d, {mode: '0755'}, function(err){//REMOTE PATH
                             if(err){
-                                gutil.log('SFTP Mkdir Error:', gutil.colors.red(err + " " +d));
+                                log.error('SFTP Mkdir Error:' + err + " " + d);
                             }else{
-                                gutil.log('SFTP Created:', gutil.colors.green(d));
+                                log.info('SFTP Created:' + d);
                             }
                             next();
                         });
@@ -292,7 +293,7 @@ module.exports = function (options) {
                     uploadedBytes+=highWaterMark;
                     var p = Math.round((uploadedBytes/size)*100);
                     p = Math.min(100,p);
-                    gutil.log('gulp-sftp:',finalRemotePath,"uploaded",(uploadedBytes/1000)+"kb");
+                    log.info('gulp-sftp:' + finalRemotePath + " uploaded " + (uploadedBytes/1000)+"kb");
                 });
 
 
@@ -301,12 +302,12 @@ module.exports = function (options) {
                 stream.on('close', function(err) {
 
                     if(err)
-                        this.emit('error', new gutil.PluginError('gulp-sftp', err));
+                        this.emit('error', new PluginError('gulp-sftp', err));
                     else{
                         if (logFiles) {
-                            gutil.log('gulp-sftp:', gutil.colors.green('Uploaded: ') +
+                            log.info('gulp-sftp: Uploaded: ' +
                                 file.relative +
-                                gutil.colors.green(' => ') +
+                                ' => ' +
                                 finalRemotePath);
                         }
 
@@ -324,9 +325,9 @@ module.exports = function (options) {
 
     }, function (cb) {
         if (fileCount > 0) {
-            gutil.log('gulp-sftp:', gutil.colors.green(fileCount, fileCount === 1 ? 'file' : 'files', 'uploaded successfully'));
+            log.info('gulp-sftp: ' + fileCount + (fileCount === 1 ? ' file' : ' files') + ' uploaded successfully');
         } else {
-            gutil.log('gulp-sftp:', gutil.colors.yellow('No files uploaded'));
+            log.warn('gulp-sftp: No files uploaded');
         }
         finished=true;
         if(sftpCache)

--- a/package.json
+++ b/package.json
@@ -41,11 +41,11 @@
   ],
   "dependencies": {
     "async": "~0.9.0",
-    "gulp-util": "~3.0.0",
+    "fancy-log": "^2.0.0",
     "object-assign": "~0.3.1",
     "parents": "~1.0.0",
-    "ssh2": "~0.6.1",
+    "plugin-error": "^2.0.1",
+    "ssh2": "~1.11.0",
     "through2": "~0.4.2"
-  },
-  "devDependencies": {}
+  }
 }


### PR DESCRIPTION
Updates SSH2 dependency to 1.11.0 version + removed gulp-util (via https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5)